### PR TITLE
Using a fixed tag for Dockerlint image

### DIFF
--- a/jenkins/jobs/dsl/docker_pipeline_jobs.groovy
+++ b/jenkins/jobs/dsl/docker_pipeline_jobs.groovy
@@ -142,7 +142,7 @@ staticCodeAnalysis.with{
     }
     shell('''set +x
             |echo "Mount the Dockerfile into a container that will run Dockerlint: https://github.com/RedCoolBeans/dockerlint"
-            |docker run --rm -v jenkins_slave_home:/jenkins_slave_home/ --entrypoint="dockerlint" redcoolbeans/dockerlint -f /jenkins_slave_home/$JOB_NAME/Dockerfile > ${WORKSPACE}/${JOB_NAME##*/}.out
+            |docker run --rm -v jenkins_slave_home:/jenkins_slave_home/ --entrypoint="dockerlint" redcoolbeans/dockerlint:0.2.0 -f /jenkins_slave_home/$JOB_NAME/Dockerfile > ${WORKSPACE}/${JOB_NAME##*/}.out
             |
             |if ! grep "Dockerfile is OK" ${WORKSPACE}/${JOB_NAME##*/}.out ; then
             | echo "Dockerfile does not satisfy Dockerlint static code analysis"


### PR DESCRIPTION
This is to remediate a defect introduced in the latest image which flags false negatives in RUN commands in the Dockerfile.
Linked issues:
https://github.com/RedCoolBeans/dockerlint/issues/49
https://github.com/RedCoolBeans/dockerlint/issues/47